### PR TITLE
fix(team-roles): remove use of 'simple'

### DIFF
--- a/documents/team-roles.md
+++ b/documents/team-roles.md
@@ -3,7 +3,7 @@
 These are some of the various roles that may be needed for an editorial piece. Other roles not listed here may be needed depending on a post, as well.
 
 * **Writer**
-* **Editor** - This may range from simple copy-editing, to providing a complete review of a piece.
+* **Editor** - This may range from copy-editing, to providing a complete review of a piece.
 * **Illustrator**
 * **Photographer**
 * **Publisher** - Takes the finished posts for a series, and publishes them in order of completion on the day agreed upon for that series.


### PR DESCRIPTION
Remove the use of 'simple' from the copy-editing role. Nothing is ever simple!

(Good work on the team-roles, @remixz :))