### PR TITLE
Fix team-roles.md as per #19

### DIFF
--- a/documents/team-roles.md
+++ b/documents/team-roles.md
@@ -3,7 +3,7 @@
 These are some of the various roles that may be needed for an editorial piece. Other roles not listed here may be needed depending on a post, as well.
 
 * **Writer** - Creator of content that will be posted to the Hoodie blog and other longform media.
-* **Editor** - Work anywhere from simple copy-editing, to providing a complete review of a piece.
+* **Editor** - Work anywhere from copy-editing, to providing a complete review of a piece.
 * **Illustrator** - Create visuals for use where needed around the Hoodie ecosystem.
 * **Photographer** - Take original photographs for use in official Hoodie media.
 * **Publisher** - Take the finished posts for a series, and publishes them in order of completion on the day agreed upon for that series.


### PR DESCRIPTION
https://github.com/hoodiehq/editorial/pull/23 introduced more content to team-roles.md, which created merge conflicts with https://github.com/hoodiehq/editorial/pull/19. This commit remakes the changes in https://github.com/hoodiehq/editorial/pull/19, with the new content.