### PR TITLE
starter-issue-template.md: remove PR step

### DIFF
--- a/starter-issue-template.md
+++ b/starter-issue-template.md
@@ -14,15 +14,10 @@ We would like to take the opportunity to invite someone who did not yet contribu
 - [ ] Go to the [`insert link to file name to be changed`)
 - [ ] Where the code is displayed (below a grey field) click on the pencil icon to the very right of the screen. 
 <img width="229" alt="screen shot 2016-02-23 at 17 50 39" src="https://cloud.githubusercontent.com/assets/2582805/13269553/641360f6-da56-11e5-8a5e-79dacd9ef39c.png">
-
 - [ ] Make your changes in the text field.
 - [ ] Describe your edits briefly under where it says **Commit changes**.
 ![Commit changes](https://cldup.com/-uX5DjuDMN-1200x1200.png)
-
 - [ ] Select the option to create a patch or a branch to begin the Pull Request process. 
-- [ ] Start a Pull Request.  
-(If this is your first, welcome :tada: :smile: [Here is a great tutorial](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github) on how to send a pull request)
-
 - [ ] You are done :clap: comment below that your pull request is ready for review :tada:
 
 Ping us in the [Hoodie Chat](http://hood.ie/chat/) or on [Twitter](https://twitter.com/hoodiehq/) if you have any questions :)


### PR DESCRIPTION
I think the "Start a Pull Request" bullet point is not needed here, the linked tutorial is more for code contributors that go through the whole git workflow, while here we ask to use github.com web UI only